### PR TITLE
Restore brand styling across site

### DIFF
--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -1,17 +1,24 @@
 :root {
-  --bg: #07111d;
-  --bg-2: #0b1627;
-  --bg-3: #0f1c31;
+  --bg: #071026;
+  --bg-2: #0b1220;
+  --bg-3: #111827;
   --panel: rgba(14, 25, 42, 0.92);
   --panel-strong: rgba(17, 31, 52, 0.98);
   --panel-soft: rgba(255, 255, 255, 0.035);
   --text: #f7fbff;
   --muted: #b0bfd2;
   --muted-2: #90a2ba;
-  --line: rgba(110, 184, 214, 0.2);
-  --line-strong: rgba(110, 184, 214, 0.35);
-  --cyan: #67e8f9;
+  --line: rgba(34, 211, 238, 0.2);
+  --line-strong: rgba(217, 70, 239, 0.35);
+  --cyan: #22d3ee;
   --sky: #38bdf8;
+  --magenta: #d946ef;
+  --brand-primary: #22d3ee;
+  --brand-secondary: #d946ef;
+  --brand-gradient: linear-gradient(135deg, #22d3ee 0%, #38bdf8 44%, #d946ef 100%);
+  --brand-glow: 0 0 34px rgba(34, 211, 238, 0.18), 0 0 44px rgba(217, 70, 239, 0.12);
+  --brand-logo-mark: url("/assets/logos/primary_logo_transparent_3000x3000.png");
+  --brand-logo-horizontal: url("/assets/logos/logo_horizontal_3000x1500.png");
   --slate: #8ab4ff;
   --green: #74f0c0;
   --amber: #fbbf24;
@@ -37,9 +44,12 @@ body {
   min-height: 100vh;
   color: var(--text);
   background:
-    radial-gradient(circle at top left, rgba(56, 189, 248, 0.12), transparent 34%),
-    radial-gradient(circle at top right, rgba(103, 232, 249, 0.08), transparent 22%),
+    linear-gradient(rgba(34, 211, 238, 0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(34, 211, 238, 0.035) 1px, transparent 1px),
+    radial-gradient(circle at top left, rgba(34, 211, 238, 0.2), transparent 34%),
+    radial-gradient(circle at top right, rgba(217, 70, 239, 0.16), transparent 28%),
     linear-gradient(180deg, var(--bg) 0%, var(--bg-2) 48%, #0c1727 100%);
+  background-size: 44px 44px, 44px 44px, auto, auto, auto;
   font-family: "Aptos", "Segoe UI Variable", "Segoe UI", sans-serif;
   line-height: 1.6;
   overflow-x: hidden;
@@ -59,7 +69,7 @@ body::before {
   right: -8rem;
   width: 24rem;
   height: 24rem;
-  background: radial-gradient(circle, rgba(103, 232, 249, 0.16), transparent 70%);
+  background: radial-gradient(circle, rgba(217, 70, 239, 0.2), transparent 70%);
   filter: blur(24px);
 }
 
@@ -68,7 +78,7 @@ body::after {
   bottom: -8rem;
   width: 26rem;
   height: 26rem;
-  background: radial-gradient(circle, rgba(56, 189, 248, 0.14), transparent 68%);
+  background: radial-gradient(circle, rgba(34, 211, 238, 0.2), transparent 68%);
   filter: blur(24px);
 }
 
@@ -85,7 +95,7 @@ a:focus-visible,
 button:focus-visible,
 input:focus-visible,
 select:focus-visible {
-  outline: 2px solid rgba(103, 232, 249, 0.9);
+  outline: 2px solid rgba(34, 211, 238, 0.9);
   outline-offset: 2px;
 }
 
@@ -124,10 +134,13 @@ main {
   position: sticky;
   top: 0;
   z-index: 30;
-  background: rgba(8, 17, 31, 0.88);
+  background:
+    linear-gradient(90deg, rgba(34, 211, 238, 0.08), transparent 22%, rgba(217, 70, 239, 0.08)),
+    rgba(7, 16, 38, 0.9);
   -webkit-backdrop-filter: blur(18px);
   backdrop-filter: blur(18px);
-  border-bottom: 1px solid rgba(103, 232, 249, 0.16);
+  border-bottom: 1px solid var(--line);
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.28), 0 1px 0 rgba(217, 70, 239, 0.16);
 }
 
 .nav {
@@ -148,6 +161,13 @@ main {
   color: var(--text);
   font-weight: 800;
   letter-spacing: 0.01em;
+  transition: color 160ms ease, transform 160ms ease;
+}
+
+.brand:hover,
+.brand:focus-visible {
+  color: var(--cyan);
+  text-decoration: none;
 }
 
 .brand-mark {
@@ -156,9 +176,22 @@ main {
   width: 42px;
   height: 42px;
   border-radius: 12px;
-  background: linear-gradient(135deg, var(--sky), var(--cyan));
+  background:
+    linear-gradient(135deg, rgba(34, 211, 238, 0.22), rgba(217, 70, 239, 0.18)),
+    var(--brand-logo-mark) center / 78% auto no-repeat,
+    rgba(7, 16, 38, 0.96);
   color: #06111f;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), var(--shadow-soft);
+  border: 1px solid rgba(34, 211, 238, 0.44);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18), var(--brand-glow), var(--shadow-soft);
+  text-indent: -9999px;
+  transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
+}
+
+.brand:hover .brand-mark,
+.brand:focus-visible .brand-mark {
+  border-color: rgba(217, 70, 239, 0.58);
+  box-shadow: 0 0 28px rgba(34, 211, 238, 0.22), 0 0 38px rgba(217, 70, 239, 0.2), var(--shadow-soft);
+  transform: translateY(-1px);
 }
 
 .nav-links {
@@ -171,21 +204,25 @@ main {
   color: var(--muted);
   padding: 0.68rem 0.85rem;
   border-radius: 999px;
-  transition: background-color 160ms ease, color 160ms ease, transform 160ms ease;
+  border: 1px solid transparent;
+  transition: background-color 160ms ease, border-color 160ms ease, color 160ms ease, transform 160ms ease, box-shadow 160ms ease;
 }
 
 .nav-links a:hover,
 .nav-links a[aria-current="page"] {
-  background: rgba(103, 232, 249, 0.12);
+  background: rgba(34, 211, 238, 0.1);
+  border-color: rgba(34, 211, 238, 0.2);
   color: var(--text);
   text-decoration: none;
   transform: translateY(-1px);
+  box-shadow: 0 10px 28px rgba(34, 211, 238, 0.08);
 }
 
 .nav-cta {
-  border: 1px solid rgba(103, 232, 249, 0.34);
+  border: 1px solid rgba(217, 70, 239, 0.38) !important;
   color: var(--text) !important;
-  background: rgba(103, 232, 249, 0.08);
+  background: linear-gradient(135deg, rgba(34, 211, 238, 0.14), rgba(217, 70, 239, 0.13)) !important;
+  box-shadow: 0 10px 28px rgba(217, 70, 239, 0.08);
 }
 
 .nav-toggle {
@@ -197,13 +234,23 @@ main {
   color: var(--text);
   font-weight: 700;
   box-shadow: var(--shadow-soft);
+  transition: border-color 160ms ease, transform 160ms ease, box-shadow 160ms ease;
+}
+
+.nav-toggle:hover {
+  border-color: var(--line-strong);
+  box-shadow: var(--brand-glow), var(--shadow-soft);
+  transform: translateY(-1px);
 }
 
 .hero {
   position: relative;
   overflow: hidden;
   padding: 6.75rem 1.25rem 4rem;
-  border-bottom: 1px solid rgba(103, 232, 249, 0.12);
+  border-bottom: 1px solid var(--line);
+  background:
+    linear-gradient(135deg, rgba(34, 211, 238, 0.08), transparent 36%, rgba(217, 70, 239, 0.08)),
+    linear-gradient(180deg, rgba(7, 16, 38, 0), rgba(7, 16, 38, 0.48));
 }
 
 .hero::before,
@@ -219,15 +266,16 @@ main {
   right: -6rem;
   width: 18rem;
   height: 18rem;
-  background: radial-gradient(circle, rgba(103, 232, 249, 0.12), transparent 70%);
+  background: radial-gradient(circle, rgba(217, 70, 239, 0.18), transparent 70%);
 }
 
 .hero::after {
-  left: -10rem;
-  bottom: -8rem;
-  width: 22rem;
-  height: 22rem;
-  background: radial-gradient(circle, rgba(56, 189, 248, 0.1), transparent 72%);
+  right: 6vw;
+  bottom: 1.8rem;
+  width: min(36rem, 45vw);
+  height: 16rem;
+  background: var(--brand-logo-horizontal) right center / contain no-repeat;
+  opacity: 0.08;
 }
 
 .hero-inner,
@@ -242,12 +290,13 @@ main {
 }
 
 .eyebrow {
-  color: var(--green);
+  color: var(--cyan);
   font-weight: 800;
   text-transform: uppercase;
   letter-spacing: 0.12em;
   font-size: 0.8rem;
   margin: 0;
+  text-shadow: 0 0 20px rgba(34, 211, 238, 0.22);
 }
 
 h1,
@@ -295,23 +344,25 @@ h3 {
   border-radius: 999px;
   padding: 0.88rem 1.08rem;
   font-weight: 800;
-  border: 1px solid rgba(103, 232, 249, 0.3);
-  background: rgba(103, 232, 249, 0.08);
+  border: 1px solid rgba(34, 211, 238, 0.32);
+  background: linear-gradient(135deg, rgba(34, 211, 238, 0.12), rgba(217, 70, 239, 0.08));
   color: var(--text);
   box-shadow: var(--shadow-soft);
-  transition: transform 160ms ease, box-shadow 160ms ease, background-color 160ms ease;
+  transition: transform 160ms ease, box-shadow 160ms ease, background-color 160ms ease, border-color 160ms ease;
 }
 
 .button:hover {
   text-decoration: none;
-  transform: translateY(-1px);
-  box-shadow: 0 14px 32px rgba(0, 0, 0, 0.2);
+  border-color: rgba(217, 70, 239, 0.44);
+  transform: translateY(-2px);
+  box-shadow: var(--brand-glow), 0 16px 34px rgba(0, 0, 0, 0.28);
 }
 
 .button.primary {
-  background: linear-gradient(135deg, var(--sky), var(--cyan));
+  background: var(--brand-gradient);
   color: #06111f;
   border: 0;
+  box-shadow: 0 14px 34px rgba(34, 211, 238, 0.16), 0 14px 34px rgba(217, 70, 239, 0.1);
 }
 
 .section {
@@ -399,10 +450,32 @@ h3 {
 .metric,
 .table-wrap,
 .panel {
-  background: linear-gradient(180deg, rgba(16, 28, 47, 0.96), rgba(11, 22, 39, 0.98));
-  border: 1px solid rgba(103, 232, 249, 0.14);
+  position: relative;
+  overflow: hidden;
+  background:
+    linear-gradient(180deg, rgba(16, 28, 47, 0.96), rgba(11, 22, 39, 0.98)),
+    linear-gradient(135deg, rgba(34, 211, 238, 0.08), rgba(217, 70, 239, 0.06));
+  border: 1px solid var(--line);
   border-radius: var(--radius);
   box-shadow: var(--shadow);
+}
+
+.card::before,
+.featured-card::before,
+.relation-card::before,
+.result-card::before,
+.stat-card::before,
+.empty-state::before,
+.search-panel::before,
+.metric::before,
+.table-wrap::before,
+.panel::before {
+  content: "";
+  position: absolute;
+  inset: 0 0 auto;
+  height: 2px;
+  background: var(--brand-gradient);
+  opacity: 0.82;
 }
 
 .card,
@@ -447,6 +520,8 @@ h3 {
   font-size: 2rem;
   font-weight: 800;
   letter-spacing: -0.03em;
+  color: var(--cyan);
+  text-shadow: 0 0 24px rgba(34, 211, 238, 0.16);
 }
 
 .stat-label {
@@ -477,18 +552,18 @@ h3 {
   border-radius: 999px;
   padding: 0.34rem 0.66rem;
   font-size: 0.82rem;
-  border: 1px solid rgba(103, 232, 249, 0.24);
+  border: 1px solid rgba(34, 211, 238, 0.24);
 }
 
 .badge,
 .chip {
-  color: var(--muted);
-  background: rgba(255, 255, 255, 0.03);
+  color: var(--text);
+  background: rgba(34, 211, 238, 0.055);
 }
 
 .status-badge {
   color: var(--text);
-  background: rgba(103, 232, 249, 0.08);
+  background: rgba(34, 211, 238, 0.08);
   font-weight: 700;
 }
 
@@ -499,7 +574,7 @@ h3 {
 
 .badge-canonical {
   color: #06111f;
-  background: linear-gradient(135deg, rgba(103, 232, 249, 0.9), rgba(56, 189, 248, 0.95));
+  background: linear-gradient(135deg, rgba(34, 211, 238, 0.9), rgba(56, 189, 248, 0.95));
   border-color: transparent;
 }
 
@@ -511,8 +586,8 @@ h3 {
 
 .badge-generated,
 .badge-documentation {
-  color: #06111f;
-  background: linear-gradient(135deg, rgba(251, 191, 36, 0.92), rgba(251, 146, 60, 0.96));
+  color: var(--text);
+  background: linear-gradient(135deg, rgba(34, 211, 238, 0.22), rgba(217, 70, 239, 0.22));
   border-color: transparent;
 }
 
@@ -539,7 +614,17 @@ h3 {
 .relation-card:hover,
 .result-card:hover,
 .stat-card:hover {
-  border-color: rgba(103, 232, 249, 0.26);
+  border-color: rgba(217, 70, 239, 0.35);
+  box-shadow: var(--brand-glow), var(--shadow);
+  transform: translateY(-2px);
+}
+
+.card,
+.featured-card,
+.relation-card,
+.result-card,
+.stat-card {
+  transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
 }
 
 .search-panel {
@@ -583,6 +668,16 @@ h3 {
   background: rgba(6, 17, 31, 0.95);
   color: var(--text);
   padding: 0.8rem 0.9rem;
+  transition: border-color 160ms ease, box-shadow 160ms ease, background-color 160ms ease;
+}
+
+.search-controls input:hover,
+.search-controls select:hover,
+.search-controls input:focus,
+.search-controls select:focus {
+  border-color: rgba(217, 70, 239, 0.42);
+  background: rgba(7, 16, 38, 0.98);
+  box-shadow: 0 0 0 4px rgba(34, 211, 238, 0.08), 0 0 24px rgba(217, 70, 239, 0.12);
 }
 
 .search-controls input::placeholder {
@@ -591,7 +686,7 @@ h3 {
 
 .result-count {
   margin: 0.9rem 0 0.2rem;
-  color: var(--green);
+  color: var(--cyan);
   font-weight: 800;
 }
 
@@ -609,7 +704,7 @@ h3 {
 
 .result-card mark,
 .featured-card mark {
-  background: rgba(103, 232, 249, 0.18);
+  background: rgba(34, 211, 238, 0.18);
   color: var(--text);
   padding: 0 0.18rem;
   border-radius: 0.18rem;
@@ -650,7 +745,7 @@ table {
 th,
 td {
   padding: 0.8rem 0.9rem;
-  border-bottom: 1px solid rgba(103, 232, 249, 0.12);
+  border-bottom: 1px solid rgba(34, 211, 238, 0.12);
   text-align: left;
   vertical-align: top;
 }
@@ -662,7 +757,7 @@ th {
 }
 
 mark {
-  background: rgba(103, 232, 249, 0.18);
+  background: rgba(34, 211, 238, 0.18);
   color: var(--text);
   padding: 0 0.18rem;
   border-radius: 0.18rem;
@@ -677,8 +772,34 @@ mark {
 .metric {
   padding: 1rem;
   border-left: 3px solid var(--cyan);
-  background: rgba(255, 255, 255, 0.035);
+  background:
+    linear-gradient(135deg, rgba(34, 211, 238, 0.08), rgba(217, 70, 239, 0.055)),
+    rgba(255, 255, 255, 0.035);
   border-radius: var(--radius-sm);
+}
+
+.metric-row {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1rem;
+  margin: 1.35rem 0 1.25rem;
+}
+
+.metric-row .metric {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.metric-row .metric strong {
+  color: var(--cyan);
+  font-size: 1.75rem;
+  line-height: 1;
+  text-shadow: 0 0 24px rgba(34, 211, 238, 0.16);
+}
+
+.metric-row .metric span {
+  color: var(--muted);
+  font-size: 0.92rem;
 }
 
 .metric .label {
@@ -690,6 +811,7 @@ mark {
   font-size: 1.8rem;
   font-weight: 800;
   margin-top: 0.2rem;
+  color: var(--cyan);
 }
 
 .metric .detail {
@@ -711,16 +833,39 @@ mark {
 }
 
 .site-footer {
-  border-top: 1px solid rgba(103, 232, 249, 0.12);
+  position: relative;
+  overflow: hidden;
+  border-top: 1px solid var(--line);
   padding: 2rem 1.25rem;
   color: var(--muted);
+  background:
+    linear-gradient(90deg, rgba(34, 211, 238, 0.08), transparent 44%, rgba(217, 70, 239, 0.1)),
+    rgba(7, 16, 38, 0.62);
+}
+
+.site-footer::after {
+  content: "";
+  position: absolute;
+  right: 1.5rem;
+  bottom: -2.6rem;
+  width: min(22rem, 42vw);
+  height: 9rem;
+  background: var(--brand-logo-horizontal) right center / contain no-repeat;
+  opacity: 0.06;
+  pointer-events: none;
 }
 
 .site-footer .section-inner {
+  position: relative;
+  z-index: 1;
   display: flex;
   justify-content: space-between;
   gap: 1rem;
   flex-wrap: wrap;
+}
+
+.site-footer a {
+  color: var(--cyan);
 }
 
 @media (max-width: 1100px) {
@@ -731,7 +876,8 @@ mark {
   }
 
   .stat-grid,
-  .metrics-grid {
+  .metrics-grid,
+  .metric-row {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
@@ -783,6 +929,7 @@ mark {
   .relationship-grid,
   .stat-grid,
   .metrics-grid,
+  .metric-row,
   .search-controls {
     grid-template-columns: 1fr;
   }

--- a/css/style.css
+++ b/css/style.css
@@ -2655,3 +2655,201 @@ article:hover,
     margin-bottom: 1.5rem;
   }
 }
+
+/* Brand restoration pass: shared legacy application stylesheet */
+:root {
+  --color-primary: #22D3EE;
+  --color-accent: #D946EF;
+  --color-secondary: #38BDF8;
+  --color-bg: #071026;
+  --color-surface: #0b1220;
+  --color-elevated: #111827;
+  --brand-gradient: linear-gradient(135deg, #22D3EE 0%, #38BDF8 44%, #D946EF 100%);
+  --brand-glow: 0 0 28px rgba(34, 211, 238, 0.18), 0 0 40px rgba(217, 70, 239, 0.12);
+}
+
+body {
+  background:
+    linear-gradient(rgba(34, 211, 238, 0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(34, 211, 238, 0.035) 1px, transparent 1px),
+    radial-gradient(circle at 16% 6%, rgba(34, 211, 238, 0.18), transparent 30%),
+    radial-gradient(circle at 84% 10%, rgba(217, 70, 239, 0.14), transparent 30%),
+    linear-gradient(180deg, #071026 0%, #0b1220 58%, #0c1727 100%) !important;
+  background-size: 44px 44px, 44px 44px, auto, auto, auto !important;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  right: clamp(1rem, 4vw, 4rem);
+  top: clamp(1rem, 8vw, 5rem);
+  width: min(30rem, 44vw);
+  height: 12rem;
+  background: url("../assets/logos/logo_horizontal_3000x1500.png") right center / contain no-repeat;
+  opacity: 0.055;
+  pointer-events: none;
+  z-index: -1;
+}
+
+.site-header {
+  background:
+    linear-gradient(90deg, rgba(34, 211, 238, 0.08), transparent 28%, rgba(217, 70, 239, 0.08)),
+    rgba(7, 16, 38, 0.92) !important;
+  border-bottom-color: rgba(34, 211, 238, 0.22) !important;
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.28), 0 1px 0 rgba(217, 70, 239, 0.16);
+}
+
+.brand,
+.footer-brand,
+.home-footer .footer-brand,
+.about-footer .footer-brand {
+  transition: transform 180ms ease, color 180ms ease;
+}
+
+.brand:hover,
+.brand:focus {
+  color: var(--color-primary);
+  transform: translateY(-1px);
+}
+
+.brand img,
+.brand img.logo,
+.footer-logo,
+.footer-brand img,
+.home-footer .footer-brand img,
+.about-footer .footer-logo {
+  background:
+    linear-gradient(135deg, rgba(34, 211, 238, 0.18), rgba(217, 70, 239, 0.14)),
+    rgba(7, 16, 38, 0.9);
+  border: 1px solid rgba(34, 211, 238, 0.28);
+  box-shadow: var(--brand-glow), 0 14px 32px rgba(0, 0, 0, 0.32) !important;
+}
+
+.nav a,
+.btn,
+button,
+.contact-email,
+.link-badge,
+.badge,
+.badge-hero,
+.tech-badge,
+.tool-pill {
+  transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease, background-color 180ms ease, color 180ms ease;
+}
+
+.nav a:hover,
+.nav a:focus,
+.btn:hover,
+.btn:focus,
+button:hover,
+button:focus,
+.contact-email:hover,
+.link-badge:hover,
+.badge:hover,
+.badge-hero:hover,
+.tech-badge:hover,
+.tool-pill:hover {
+  border-color: rgba(217, 70, 239, 0.38);
+  box-shadow: var(--brand-glow), 0 14px 30px rgba(0, 0, 0, 0.25);
+  transform: translateY(-2px);
+  text-decoration: none;
+}
+
+.btn,
+button,
+.contact-email,
+.link-badge {
+  background: linear-gradient(135deg, rgba(34, 211, 238, 0.12), rgba(217, 70, 239, 0.08));
+  border-color: rgba(34, 211, 238, 0.28);
+}
+
+.btn.primary,
+.btn-primary,
+button.primary {
+  background: var(--brand-gradient) !important;
+  color: #06111f !important;
+}
+
+.card,
+article,
+.frosted-card,
+.highlights .card,
+.about-cards .card,
+.card-grid .card,
+.timeline-card .card,
+.result,
+.dashboard-section,
+.evidence-item,
+.project-card,
+.panel,
+.doc-card,
+.contact-panel {
+  position: relative;
+  overflow: hidden;
+  background:
+    linear-gradient(180deg, rgba(16, 28, 47, 0.94), rgba(11, 22, 39, 0.96)) !important;
+  border: 1px solid rgba(34, 211, 238, 0.2) !important;
+}
+
+.card::before,
+article::before,
+.frosted-card::before,
+.highlights .card::before,
+.about-cards .card::before,
+.card-grid .card::before,
+.timeline-card .card::before,
+.result::before,
+.dashboard-section::before,
+.evidence-item::before,
+.project-card::before,
+.panel::before,
+.doc-card::before,
+.contact-panel::before {
+  content: "";
+  position: absolute;
+  inset: 0 0 auto;
+  height: 2px;
+  background: var(--brand-gradient);
+  opacity: 0.86;
+}
+
+.card:hover,
+article:hover,
+.frosted-card:hover,
+.highlights .card:hover,
+.about-cards .card:hover,
+.card-grid .card:hover,
+.timeline-card:hover .card,
+.result:hover,
+.dashboard-section:hover,
+.evidence-item:hover,
+.project-card:hover,
+.panel:hover,
+.doc-card:hover,
+.contact-panel:hover {
+  border-color: rgba(217, 70, 239, 0.36) !important;
+  box-shadow: var(--brand-glow), 0 22px 48px rgba(0, 0, 0, 0.34);
+}
+
+.site-footer,
+.home-footer,
+.about-footer,
+.skills-footer,
+.experience-footer,
+.docs-footer,
+.contact-footer {
+  position: relative;
+  overflow: hidden;
+  border-top: 1px solid rgba(34, 211, 238, 0.22);
+  background:
+    linear-gradient(90deg, rgba(34, 211, 238, 0.08), transparent 44%, rgba(217, 70, 239, 0.1)),
+    rgba(7, 16, 38, 0.86) !important;
+}
+
+@media (max-width: 768px) {
+  body::before {
+    width: 16rem;
+    height: 7rem;
+    opacity: 0.04;
+  }
+}

--- a/css/styles.css
+++ b/css/styles.css
@@ -894,3 +894,177 @@ h3 {
     margin-bottom: 1.25rem;
   }
 }
+
+/* Brand restoration pass: shared legacy documentation stylesheet */
+:root {
+  --bg-primary: #071026;
+  --bg-secondary: #0b1220;
+  --surface: #111827;
+  --glass: rgba(14, 25, 42, 0.82);
+  --line: rgba(34, 211, 238, 0.2);
+  --line-strong: rgba(217, 70, 239, 0.34);
+  --accent-cyan: #22d3ee;
+  --accent-cyan-bright: #38bdf8;
+  --accent-magenta: #d946ef;
+  --accent-purple: #8ab4ff;
+  --shadow: 0 22px 56px rgba(0, 0, 0, 0.32);
+  --glow-cyan: 0 0 20px rgba(34, 211, 238, 0.22), 0 0 42px rgba(34, 211, 238, 0.1);
+  --glow-magenta: 0 0 20px rgba(217, 70, 239, 0.2), 0 0 42px rgba(217, 70, 239, 0.1);
+}
+
+body {
+  background:
+    linear-gradient(rgba(34, 211, 238, 0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(34, 211, 238, 0.035) 1px, transparent 1px),
+    radial-gradient(circle at 16% 6%, rgba(34, 211, 238, 0.18), transparent 30%),
+    radial-gradient(circle at 84% 10%, rgba(217, 70, 239, 0.14), transparent 30%),
+    linear-gradient(180deg, #071026 0%, #0b1220 58%, #0c1727 100%) !important;
+  background-size: 44px 44px, 44px 44px, auto, auto, auto !important;
+}
+
+body > .container,
+body > .page-shell,
+body > .docs-hub {
+  position: relative;
+  isolation: isolate;
+}
+
+body > .container::before,
+body > .page-shell::before,
+body > .docs-hub::before {
+  content: "";
+  position: fixed;
+  right: clamp(1rem, 5vw, 4rem);
+  top: clamp(1rem, 8vw, 5rem);
+  width: min(28rem, 42vw);
+  height: 12rem;
+  background: url("../assets/logos/logo_horizontal_3000x1500.png") right center / contain no-repeat;
+  opacity: 0.055;
+  pointer-events: none;
+  z-index: -1;
+}
+
+a {
+  color: var(--accent-cyan);
+}
+
+a:hover,
+a:focus {
+  color: var(--accent-cyan-bright);
+}
+
+.doc-nav a,
+.nav-link,
+.button,
+.btn,
+button,
+input,
+select,
+textarea {
+  transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease, background-color 180ms ease, color 180ms ease;
+}
+
+.doc-nav a:hover,
+.nav-link:hover,
+.button:hover,
+.btn:hover,
+button:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--glow-cyan), 0 14px 30px rgba(0, 0, 0, 0.25);
+  text-decoration: none;
+}
+
+.container,
+.page-shell,
+.docs-hub {
+  color: var(--text-primary);
+}
+
+.container h1::before,
+.page-title::before,
+.docs-hero h1::before {
+  content: "";
+  display: block;
+  width: 4.25rem;
+  height: 4.25rem;
+  margin: 0 0 1rem;
+  border-radius: 1rem;
+  background:
+    linear-gradient(135deg, rgba(34, 211, 238, 0.22), rgba(217, 70, 239, 0.16)),
+    url("../assets/logos/primary_logo_transparent_3000x3000.png") center / 78% auto no-repeat,
+    rgba(7, 16, 38, 0.92);
+  border: 1px solid rgba(34, 211, 238, 0.34);
+  box-shadow: var(--glow-cyan), 0 14px 30px rgba(0, 0, 0, 0.28);
+}
+
+.hero-visual,
+.panel,
+.card,
+.project-card,
+.doc-card,
+.contact-panel,
+.evidence-item,
+.result,
+.modal-panel,
+.frosted-panel,
+.dashboard-section {
+  position: relative;
+  overflow: hidden;
+  background:
+    linear-gradient(180deg, rgba(16, 28, 47, 0.94), rgba(11, 22, 39, 0.96)) !important;
+  border: 1px solid var(--line) !important;
+}
+
+.hero-visual::before,
+.panel::before,
+.card::before,
+.project-card::before,
+.doc-card::before,
+.contact-panel::before,
+.evidence-item::before,
+.result::before,
+.modal-panel::before,
+.frosted-panel::before,
+.dashboard-section::before {
+  content: "";
+  position: absolute;
+  inset: 0 0 auto;
+  height: 2px;
+  background: linear-gradient(90deg, var(--accent-cyan), var(--accent-cyan-bright), var(--accent-magenta));
+  opacity: 0.86;
+}
+
+.hero-visual:hover,
+.panel:hover,
+.card:hover,
+.project-card:hover,
+.doc-card:hover,
+.contact-panel:hover,
+.evidence-item:hover,
+.result:hover,
+.modal-panel:hover,
+.frosted-panel:hover,
+.dashboard-section:hover {
+  border-color: rgba(217, 70, 239, 0.36) !important;
+  box-shadow: var(--glow-cyan), var(--glow-magenta), 0 22px 48px rgba(0, 0, 0, 0.34);
+}
+
+.footer,
+.docs-footer {
+  position: relative;
+  overflow: hidden;
+  border-top: 1px solid var(--line);
+  background:
+    linear-gradient(90deg, rgba(34, 211, 238, 0.08), transparent 44%, rgba(217, 70, 239, 0.1)),
+    rgba(7, 16, 38, 0.8);
+}
+
+@media (max-width: 820px) {
+  body > .container::before,
+  body > .page-shell::before,
+  body > .docs-hub::before {
+    width: 16rem;
+    height: 7rem;
+    opacity: 0.04;
+  }
+}

--- a/docs/home-lab/architecture-and-topology.html
+++ b/docs/home-lab/architecture-and-topology.html
@@ -17,6 +17,7 @@
         code { background: #e2e8f0; padding: 0.1rem 0.3rem; border-radius: 4px; }
     </style>
   <link rel="canonical" href="https://jeremyfontenot.online/docs/home-lab/architecture-and-topology.html" />
+<link rel="stylesheet" href="/assets/css/site.css">
 </head>
 <body>
     <main>

--- a/docs/home-lab/asset-inventory.html
+++ b/docs/home-lab/asset-inventory.html
@@ -16,6 +16,7 @@
         a:hover { text-decoration: underline; }
     </style>
   <link rel="canonical" href="https://jeremyfontenot.online/docs/home-lab/asset-inventory.html" />
+<link rel="stylesheet" href="/assets/css/site.css">
 </head>
 <body>
     <main>

--- a/docs/home-lab/backup-and-disaster-recovery.html
+++ b/docs/home-lab/backup-and-disaster-recovery.html
@@ -15,6 +15,7 @@
         .targets { background: #f1f5f9; border: 1px solid #e2e8f0; border-radius: 8px; padding: 12px; }
     </style>
   <link rel="canonical" href="https://jeremyfontenot.online/docs/home-lab/backup-and-disaster-recovery.html" />
+<link rel="stylesheet" href="/assets/css/site.css">
 </head>
 <body>
     <main>

--- a/docs/home-lab/change-management-and-validation.html
+++ b/docs/home-lab/change-management-and-validation.html
@@ -14,6 +14,7 @@
         a:hover { text-decoration: underline; }
     </style>
   <link rel="canonical" href="https://jeremyfontenot.online/docs/home-lab/change-management-and-validation.html" />
+<link rel="stylesheet" href="/assets/css/site.css">
 </head>
 <body>
     <main>

--- a/docs/home-lab/identity-and-access.html
+++ b/docs/home-lab/identity-and-access.html
@@ -15,6 +15,7 @@
         .callout { background: #f1f5f9; border-left: 4px solid #0ea5e9; padding: 10px 12px; }
     </style>
   <link rel="canonical" href="https://jeremyfontenot.online/docs/home-lab/identity-and-access.html" />
+<link rel="stylesheet" href="/assets/css/site.css">
 </head>
 <body>
     <main>

--- a/docs/home-lab/index.html
+++ b/docs/home-lab/index.html
@@ -62,6 +62,7 @@
         }
     </style>
   <link rel="canonical" href="https://jeremyfontenot.online/docs/home-lab/" />
+<link rel="stylesheet" href="/assets/css/site.css">
 </head>
 <body>
     <div class="wrap">

--- a/docs/home-lab/infrastructure-and-network.html
+++ b/docs/home-lab/infrastructure-and-network.html
@@ -15,6 +15,7 @@
         .meta { background: #f1f5f9; border: 1px solid #e2e8f0; border-radius: 8px; padding: 12px; }
     </style>
   <link rel="canonical" href="https://jeremyfontenot.online/docs/home-lab/infrastructure-and-network.html" />
+<link rel="stylesheet" href="/assets/css/site.css">
 </head>
 <body>
     <main>

--- a/docs/home-lab/monitoring-and-logging.html
+++ b/docs/home-lab/monitoring-and-logging.html
@@ -14,6 +14,7 @@
         a:hover { text-decoration: underline; }
     </style>
   <link rel="canonical" href="https://jeremyfontenot.online/docs/home-lab/monitoring-and-logging.html" />
+<link rel="stylesheet" href="/assets/css/site.css">
 </head>
 <body>
     <main>

--- a/docs/home-lab/operations-and-monitoring.html
+++ b/docs/home-lab/operations-and-monitoring.html
@@ -14,6 +14,7 @@
         a:hover { text-decoration: underline; }
     </style>
   <link rel="canonical" href="https://jeremyfontenot.online/docs/home-lab/operations-and-monitoring.html" />
+<link rel="stylesheet" href="/assets/css/site.css">
 </head>
 <body>
     <main>

--- a/docs/home-lab/operations-runbook.html
+++ b/docs/home-lab/operations-runbook.html
@@ -15,6 +15,7 @@
         a:hover { text-decoration: underline; }
     </style>
   <link rel="canonical" href="https://jeremyfontenot.online/docs/home-lab/operations-runbook.html" />
+<link rel="stylesheet" href="/assets/css/site.css">
 </head>
 <body>
     <main>

--- a/docs/home-lab/security-baseline.html
+++ b/docs/home-lab/security-baseline.html
@@ -14,6 +14,7 @@
         a:hover { text-decoration: underline; }
     </style>
   <link rel="canonical" href="https://jeremyfontenot.online/docs/home-lab/security-baseline.html" />
+<link rel="stylesheet" href="/assets/css/site.css">
 </head>
 <body>
     <main>

--- a/docs/home-lab/validation-report.html
+++ b/docs/home-lab/validation-report.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang='en'><head><meta charset='UTF-8'><meta name='viewport' content='width=device-width, initial-scale=1.0'><meta name="description" content="Home lab validation report covering documentation quality, link health, evidence review, configuration notes, and public portfolio readiness.">
   <title>Home Lab Docs Validation Report</title><style>body{font-family:Segoe UI,Tahoma,sans-serif;background:#f8fafc;color:#0f172a;margin:0;padding:24px}main{max-width:1100px;margin:0 auto;background:#fff;border:1px solid #e2e8f0;border-radius:10px;padding:16px}table{width:100%;border-collapse:collapse}th,td{border:1px solid #e2e8f0;padding:8px;text-align:left}th{background:#e2e8f0}.ok{color:#047857;font-weight:700}.bad{color:#b91c1c;font-weight:700}a{color:#0369a1;text-decoration:none}a:hover{text-decoration:underline}</style>  <link rel="canonical" href="https://jeremyfontenot.online/docs/home-lab/validation-report.html" />
+<link rel="stylesheet" href="/assets/css/site.css">
 </head><body><main>
 <h1>Home Lab Documentation Validation</h1>
   <p>The validation report summarizes the documented home lab pages that were checked for public portfolio readiness. It gives reviewers a quick view of whether each page passed relative-link validation and whether any local documentation references require follow-up. The report is intentionally narrow: it validates documentation quality and navigation health, not live production infrastructure.</p>

--- a/docs/homelab/index.html
+++ b/docs/homelab/index.html
@@ -199,6 +199,7 @@
   <meta name="twitter:title" content="Homelab Architecture — Jeremy Fontenot">
   <meta name="twitter:description" content="Homelab architecture, diagrams, and documentation for Jeremy Fontenot">
   <meta name="twitter:image" content="https://jeremyfontenot.online/assets/og/og-portfolio.png">
+<link rel="stylesheet" href="/assets/css/site.css">
 </head>
 <body class="text-slate-100">
   <header class="nav-wrap">

--- a/docs/identity-security/index.html
+++ b/docs/identity-security/index.html
@@ -37,6 +37,7 @@
   <meta name="twitter:title" content="Identity & Security — Documentation">
   <meta name="twitter:description" content="Identity and security documentation: Active Directory, Entra ID, MFA, Conditional Access, and identity lifecycle.">
   <meta name="twitter:image" content="https://jeremyfontenot.online/assets/og/og-portfolio.png">
+<link rel="stylesheet" href="/assets/css/site.css">
 </head>
 <body class="bg-bg text-slate-100 antialiased">
   <header class="sticky top-0 bg-bg/90 border-b border-slate-800">

--- a/docs/powershell/index.html
+++ b/docs/powershell/index.html
@@ -37,6 +37,7 @@
   <meta name="twitter:title" content="PowerShell & Automation | Jeremy Fontenot Documentation">
   <meta name="twitter:description" content="PowerShell scripts, modules, and automation examples for provisioning and reporting.">
   <meta name="twitter:image" content="https://jeremyfontenot.online/assets/og/og-portfolio.png">
+<link rel="stylesheet" href="/assets/css/site.css">
 </head>
 <body class="bg-bg text-slate-100 antialiased">
   <header class="sticky top-0 bg-bg/90 border-b border-slate-800">

--- a/docs/server-guides/index.html
+++ b/docs/server-guides/index.html
@@ -37,6 +37,7 @@
   <meta name="twitter:title" content="Server Guides | Jeremy Fontenot Documentation">
   <meta name="twitter:description" content="Server guides: Windows Server roles, DNS, DHCP, file services, and hardening.">
   <meta name="twitter:image" content="https://jeremyfontenot.online/assets/og/og-portfolio.png">
+<link rel="stylesheet" href="/assets/css/site.css">
 </head>
 <body class="bg-bg text-slate-100 antialiased">
   <header class="sticky top-0 bg-bg/90 border-b border-slate-800">

--- a/docs/troubleshooting/index.html
+++ b/docs/troubleshooting/index.html
@@ -37,6 +37,7 @@
   <meta name="twitter:title" content="Troubleshooting Playbooks | Jeremy Fontenot Documentation">
   <meta name="twitter:description" content="Troubleshooting playbooks: DNS, authentication, network connectivity, and incident RCA.">
   <meta name="twitter:image" content="https://jeremyfontenot.online/assets/og/og-portfolio.png">
+<link rel="stylesheet" href="/assets/css/site.css">
 </head>
 <body class="bg-bg text-slate-100 antialiased">
   <header class="sticky top-0 bg-bg/90 border-b border-slate-800">

--- a/evidence/public/index.html
+++ b/evidence/public/index.html
@@ -38,6 +38,7 @@
   <meta name="twitter:title" content="Evidence Files - Moved">
   <meta name="twitter:description" content="Evidence Files - Moved body { font-family: -apple-system, BlinkMacSystemFont,">
   <meta name="twitter:image" content="https://jeremyfontenot.online/assets/og/og-portfolio.png">
+<link rel="stylesheet" href="/assets/css/site.css">
 </head>
 <body>
   <div class="container">

--- a/linkedin.html
+++ b/linkedin.html
@@ -18,6 +18,7 @@
   <meta name="twitter:title" content="LinkedIn Legacy Alias - Jeremy Fontenot">
   <meta name="twitter:description" content="Legacy contact alias. Visit the contact options page for current profile links.">
   <meta name="twitter:image" content="https://jeremyfontenot.online/assets/og/og-portfolio.png">
+<link rel="stylesheet" href="/assets/css/site.css">
 </head>
 <body>
   <h1>Contact Options</h1>

--- a/observability/reports/execution_metrics.json
+++ b/observability/reports/execution_metrics.json
@@ -1,7 +1,7 @@
 {
   "metric_type": "execution_layer_health",
-  "timestamp": "2026-05-20T18:11:08.277296Z",
-  "workflow_run": "https://github.com/jeremyfontenot/JeremyFontenot.github.io/actions/runs/26181069360",
+  "timestamp": "2026-05-20T19:14:13.988078Z",
+  "workflow_run": "https://github.com/jeremyfontenot/JeremyFontenot.github.io/actions/runs/26184306698",
   "verification_completed": false,
   "system_incidents": false,
   "seo_incidents": false

--- a/observability/reports/execution_metrics.json
+++ b/observability/reports/execution_metrics.json
@@ -1,7 +1,7 @@
 {
   "metric_type": "execution_layer_health",
-  "timestamp": "2026-05-20T19:14:13.988078Z",
-  "workflow_run": "https://github.com/jeremyfontenot/JeremyFontenot.github.io/actions/runs/26184306698",
+  "timestamp": "2026-05-20T18:11:08.277296Z",
+  "workflow_run": "https://github.com/jeremyfontenot/JeremyFontenot.github.io/actions/runs/26181069360",
   "verification_completed": false,
   "system_incidents": false,
   "seo_incidents": false


### PR DESCRIPTION
## Summary
- Restores the portfolio brand palette to deep navy, cyan, sky, and magenta across the shared active stylesheets.
- Adds logo-based brand treatment through the shared CSS, including nav marks, hero/footer watermarking, and legacy page overlays where feasible.
- Adds the shared branded stylesheet to active legacy pages that previously relied only on inline styling.

## Validation
- `node scripts/audit-site.mjs`
- `python tools/validate_manifest.py`
- `npx html-validate@9 --config .htmlvalidate.json (Get-Content artifacts\active-html-files.txt)`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File .\scripts\validation\Invoke-RepositoryPolicyValidation.ps1`
- Local Node smoke check for representative pages and brand assets

## Scope notes
- No `docs/archive/` changes.
- Generated sitemap/report timestamp changes from validation were restored before commit.