### PR TITLE
Harden validation scripts and workflow quality gate

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -17,6 +17,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Validate PowerShell syntax
+        shell: pwsh
+        run: .\scripts\validation\validate-powershell.ps1
+
       - name: Validate repository structure
         shell: pwsh
         run: .\scripts\validation\validate-repo-structure.ps1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,9 @@ git diff --check
 For JavaScript:
 node --check .\path\to\file.js
 
+For PowerShell:
+pwsh -NoProfile -File .\scripts\validation\validate-powershell.ps1
+
 ## Commit Standard
 
 Use clear commit messages.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -38,10 +38,10 @@ For JavaScript files, run:
 node --check .\path\to\script.js
 ```
 
-For PowerShell files, run:
+For PowerShell files, run syntax validation:
 
 ```powershell
-Get-Command .\path\to\script.ps1
+pwsh -NoProfile -File .\scripts\validation\validate-powershell.ps1
 ```
 
 ## Naming Standard

--- a/scripts/validation/validate-html.ps1
+++ b/scripts/validation/validate-html.ps1
@@ -1,28 +1,38 @@
-Write-Host "Validating HTML files..."
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
 
-$HtmlFiles = Get-ChildItem -Path . -Recurse -Filter "*.html" -File | Where-Object {
-  $_.DirectoryName -notmatch "node_modules"
+Write-Host 'Validating HTML files...'
+
+$HtmlFiles = Get-ChildItem -Path . -Recurse -Filter '*.html' -File | Where-Object {
+  $_.FullName -notmatch '[\\/]node_modules[\\/]'
 }
 
 if (-not $HtmlFiles) {
-  Write-Host "No HTML files found." -ForegroundColor Red
+  Write-Host 'No HTML files found.' -ForegroundColor Red
   exit 1
 }
 
-$Failures = @()
+$Failures = [System.Collections.Generic.List[string]]::new()
 
 foreach ($File in $HtmlFiles) {
-  $Content = Get-Content $File.FullName -Raw
-
-  if ($Content -notmatch "<html") {
-    $Failures += $File.FullName
-    Write-Host "Missing html tag: $($File.FullName)" -ForegroundColor Red
+  try {
+    $Content = Get-Content -Path $File.FullName -Raw -ErrorAction Stop
+  } catch {
+    $Failures.Add($File.FullName)
+    Write-Host "Unable to read file: $($File.FullName)" -ForegroundColor Red
+    Write-Host "  $($_.Exception.Message)" -ForegroundColor Red
     continue
   }
 
-  if ($Content -notmatch "</html>") {
-    $Failures += $File.FullName
-    Write-Host "Missing closing html tag: $($File.FullName)" -ForegroundColor Red
+  if ($Content -notmatch '<html') {
+    $Failures.Add($File.FullName)
+    Write-Host "Missing <html tag in: $($File.FullName)" -ForegroundColor Red
+    continue
+  }
+
+  if ($Content -notmatch '</html>') {
+    $Failures.Add($File.FullName)
+    Write-Host "Missing </html> tag in: $($File.FullName)" -ForegroundColor Red
     continue
   }
 
@@ -30,10 +40,10 @@ foreach ($File in $HtmlFiles) {
 }
 
 if ($Failures.Count -gt 0) {
-  Write-Host ""
-  Write-Host "HTML validation failed." -ForegroundColor Red
+  Write-Host ''
+  Write-Host ("HTML validation failed for {0} file(s)." -f $Failures.Count) -ForegroundColor Red
   exit 1
 }
 
-Write-Host ""
-Write-Host "HTML validation passed." -ForegroundColor Green
+Write-Host ''
+Write-Host 'HTML validation passed.' -ForegroundColor Green

--- a/scripts/validation/validate-json.ps1
+++ b/scripts/validation/validate-json.ps1
@@ -1,26 +1,35 @@
-Write-Host "Validating JSON files..."
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
 
-$JsonFiles = Get-ChildItem -Path . -Recurse -Filter "*.json" -File | Where-Object {
-  $_.DirectoryName -notmatch "node_modules"
+Write-Host 'Validating JSON files...'
+
+$JsonFiles = Get-ChildItem -Path . -Recurse -Filter '*.json' -File | Where-Object {
+  $_.FullName -notmatch '[\\/]node_modules[\\/]'
 }
 
-$Failures = @()
+if (-not $JsonFiles) {
+  Write-Host 'No JSON files found.' -ForegroundColor Yellow
+  exit 0
+}
+
+$Failures = [System.Collections.Generic.List[string]]::new()
 
 foreach ($File in $JsonFiles) {
   try {
-    Get-Content $File.FullName -Raw | ConvertFrom-Json -AsHashtable | Out-Null
+    Get-Content -Path $File.FullName -Raw -ErrorAction Stop | ConvertFrom-Json -AsHashtable -ErrorAction Stop | Out-Null
     Write-Host "Valid: $($File.FullName)"
   } catch {
-    $Failures += $File.FullName
-    Write-Host "Invalid: $($File.FullName)" -ForegroundColor Red
+    $Failures.Add($File.FullName)
+    Write-Host "Invalid JSON: $($File.FullName)" -ForegroundColor Red
+    Write-Host "  $($_.Exception.Message)" -ForegroundColor Red
   }
 }
 
 if ($Failures.Count -gt 0) {
-  Write-Host ""
-  Write-Host "JSON validation failed." -ForegroundColor Red
+  Write-Host ''
+  Write-Host ("JSON validation failed for {0} file(s)." -f $Failures.Count) -ForegroundColor Red
   exit 1
 }
 
-Write-Host ""
-Write-Host "JSON validation passed." -ForegroundColor Green
+Write-Host ''
+Write-Host 'JSON validation passed.' -ForegroundColor Green

--- a/scripts/validation/validate-links.ps1
+++ b/scripts/validation/validate-links.ps1
@@ -1,42 +1,50 @@
-Write-Host "Validating internal links..."
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
 
-$HtmlFiles = Get-ChildItem -Path . -Recurse -Filter "*.html" -File | Where-Object {
-  $_.DirectoryName -notmatch "node_modules"
+Write-Host 'Validating internal links...'
+
+$HtmlFiles = Get-ChildItem -Path . -Recurse -Filter '*.html' -File | Where-Object {
+  $_.FullName -notmatch '[\\/]node_modules[\\/]'
 }
 
-$Failures = @()
+if (-not $HtmlFiles) {
+  Write-Host 'No HTML files found for link validation.' -ForegroundColor Red
+  exit 1
+}
+
+$Failures = [System.Collections.Generic.List[string]]::new()
 
 foreach ($File in $HtmlFiles) {
-
   $Matches = Select-String -Path $File.FullName -Pattern '(?:href|src)="([^"]+)"' -AllMatches
 
   foreach ($Match in $Matches.Matches) {
-
-    $RelativePath = ($Match.Groups[1].Value -split "\?")[0]
+    $RelativePath = ($Match.Groups[1].Value -split '\?')[0]
 
     if (
-      $RelativePath.StartsWith("http") -or
-      $RelativePath.StartsWith("#") -or
-      $RelativePath.StartsWith("mailto:") -or
-      $RelativePath.StartsWith("tel:")
+      [string]::IsNullOrWhiteSpace($RelativePath) -or
+      $RelativePath.StartsWith('http') -or
+      $RelativePath.StartsWith('#') -or
+      $RelativePath.StartsWith('mailto:') -or
+      $RelativePath.StartsWith('tel:') -or
+      $RelativePath.StartsWith('//')
     ) {
       continue
     }
 
-    $ResolvedPath = Join-Path $File.DirectoryName $RelativePath
+    $ResolvedPath = Join-Path -Path $File.DirectoryName -ChildPath $RelativePath
 
-    if (-not (Test-Path $ResolvedPath)) {
-      $Failures += $ResolvedPath
-      Write-Host "Missing: $ResolvedPath" -ForegroundColor Red
+    if (-not (Test-Path -Path $ResolvedPath)) {
+      $Failures.Add("$($File.FullName) => $RelativePath")
+      Write-Host "Missing reference in $($File.FullName): $RelativePath" -ForegroundColor Red
     }
   }
 }
 
 if ($Failures.Count -gt 0) {
-  Write-Host ""
-  Write-Host "Link validation failed." -ForegroundColor Red
+  Write-Host ''
+  Write-Host ("Link validation failed for {0} reference(s)." -f $Failures.Count) -ForegroundColor Red
   exit 1
 }
 
-Write-Host ""
-Write-Host "Link validation passed." -ForegroundColor Green
+Write-Host ''
+Write-Host 'Link validation passed.' -ForegroundColor Green

--- a/scripts/validation/validate-powershell.ps1
+++ b/scripts/validation/validate-powershell.ps1
@@ -1,0 +1,45 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Write-Host 'Validating PowerShell script syntax...'
+
+$PowerShellFiles = Get-ChildItem -Path . -Recurse -Filter '*.ps1' -File | Where-Object {
+  $_.FullName -notmatch '[\\/]node_modules[\\/]'
+}
+
+if (-not $PowerShellFiles) {
+  Write-Host 'No PowerShell files found to validate.' -ForegroundColor Yellow
+  exit 0
+}
+
+$Failures = [System.Collections.Generic.List[string]]::new()
+
+foreach ($File in $PowerShellFiles) {
+  $tokens = $null
+  $parseErrors = $null
+  [void][System.Management.Automation.Language.Parser]::ParseFile($File.FullName, [ref]$tokens, [ref]$parseErrors)
+
+  if ($parseErrors -and $parseErrors.Count -gt 0) {
+    $Failures.Add($File.FullName)
+    Write-Host "Syntax errors in: $($File.FullName)" -ForegroundColor Red
+
+    foreach ($parseError in $parseErrors) {
+      $line = $parseError.Extent.StartLineNumber
+      $column = $parseError.Extent.StartColumnNumber
+      Write-Host ("  Line {0}, Col {1}: {2}" -f $line, $column, $parseError.Message) -ForegroundColor Red
+    }
+
+    continue
+  }
+
+  Write-Host "Valid: $($File.FullName)"
+}
+
+if ($Failures.Count -gt 0) {
+  Write-Host ''
+  Write-Host ("PowerShell syntax validation failed for {0} file(s)." -f $Failures.Count) -ForegroundColor Red
+  exit 1
+}
+
+Write-Host ''
+Write-Host 'PowerShell syntax validation passed.' -ForegroundColor Green

--- a/scripts/validation/validate-repo-structure.ps1
+++ b/scripts/validation/validate-repo-structure.ps1
@@ -1,27 +1,30 @@
-Write-Host "Validating repository structure..."
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Write-Host 'Validating repository structure...'
 
 $RequiredPaths = @(
-  ".github",
-  "assets",
-  "docs",
-  "scripts",
-  "evidence-library"
+  '.github',
+  'assets',
+  'docs',
+  'scripts',
+  'evidence-library'
 )
 
-$Missing = @()
+$Missing = [System.Collections.Generic.List[string]]::new()
 
 foreach ($Path in $RequiredPaths) {
-  if (-not (Test-Path $Path)) {
-    $Missing += $Path
+  if (-not (Test-Path -Path $Path)) {
+    $Missing.Add($Path)
   }
 }
 
 if ($Missing.Count -gt 0) {
-  Write-Host ""
-  Write-Host "Missing required paths:" -ForegroundColor Red
+  Write-Host ''
+  Write-Host 'Missing required paths:' -ForegroundColor Red
   $Missing | ForEach-Object { Write-Host "- $_" -ForegroundColor Red }
   exit 1
 }
 
-Write-Host ""
-Write-Host "Repository structure validation passed." -ForegroundColor Green
+Write-Host ''
+Write-Host 'Repository structure validation passed.' -ForegroundColor Green


### PR DESCRIPTION
### Motivation
- The repository validation gate lacked PowerShell syntax checking and provided limited diagnostics, which reduced CI determinism and made failures hard to triage. 
- The intent is to strengthen the CI quality gate while preserving Windows GitHub Actions compatibility and excluding `node_modules` from checks.

### Description
- Added `scripts/validation/validate-powershell.ps1` which uses the PowerShell parser to detect syntax errors and reports line/column diagnostics.  
- Hardened existing validators (`scripts/validation/validate-html.ps1`, `validate-json.ps1`, `validate-links.ps1`, `validate-repo-structure.ps1`) with `Set-StrictMode`, `$ErrorActionPreference = 'Stop'`, improved error messages, and `System.Collections.Generic.List[string]` for consistent failure reporting while excluding `node_modules`.  
- Updated `.github/workflows/validation.yml` to run all validators (including the new PowerShell step) using `pwsh` with simple, readable steps.  
- Updated documentation (`scripts/README.md` and `CONTRIBUTING.md`) to document PowerShell syntax validation and the recommended `pwsh -NoProfile -File .\scripts\validation\validate-powershell.ps1` command.

### Testing
- Validation commands run: `git diff --check` (passed), `git status --short` (used to confirm staged/working files), attempted `pwsh -NoProfile -File ./scripts/validation/validate-powershell.ps1` and `powershell -NoProfile -File ./scripts/validation/validate-powershell.ps1` (both failed in this environment because `pwsh`/`powershell` are not installed).  
- Automated checks: `git diff --check` succeeded with no issues reported.  
- Commit: changes were committed with message `Harden validation scripts and CI quality gate` and commit hash `6f243c8e865cf258ee7e10053ee5f8ac5c122ca0`.  
- Push: `git push origin HEAD:main` failed because this environment has no `origin` remote configured and cannot push to `main` from here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a149da1e22c8327b64d4734ffb0e190)